### PR TITLE
Support diff syntax

### DIFF
--- a/colors/fruchtig.vim
+++ b/colors/fruchtig.vim
@@ -63,3 +63,6 @@ hi! link Todo             PreProc
 hi! link schemeError      PreProc
 hi! link TabLineSel       StatusLine
 hi! link PmenuSel         WildMenu
+
+hi       diffAdded   guifg=#43C464
+hi! link diffRemoved PreProc


### PR DESCRIPTION
I had to look this up, so: `DiffAdd`, `DiffDelete`, etc are used for diff mode, eg when starting vim with `vimdiff`. The [diff syntax](https://github.com/vim/vim/blob/a87b72cc316e065d66dcbcf7ec1cde330adef3a3/runtime/syntax/diff.vim) is what's used for output of the `diff` program and for git diffs, and this syntax uses the similarly named highlight groups `diffAdded`, `diffRemoved`, etc.

So with this PR we get proper coloring eg when doing `git commit --verbose`. I could have linked `diffAdded` to `Comment` but I liked the green you use for `StatusLine` which pops more.